### PR TITLE
springtainer-redis: Update auf Spring Boot 4.1.X und Java 25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Runs only on push to the master branch
       - master
+      - spring-boot-4-migration
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # Runs only on push to the master branch
       - master
-      - spring-boot-4-migration
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <dependency>
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-redis</artifactId>
-  <version>2.0.0</version>
+  <version>3.0.0-RC1</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
-    <maven-scm-provider-gitexe.version>1.11.3</maven-scm-provider-gitexe.version>
+    <maven-scm-provider-gitexe.version>2.2.1</maven-scm-provider-gitexe.version>
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Common -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-redis</artifactId>
-  <version>2.0.0</version>
+  <version>3.0.0-RC1</version>
 
   <name>springtainer-redis</name>
   <description>Redis test-container</description>
@@ -44,7 +44,7 @@
     <!-- Build -->
     <maven.build.timestamp.format>dd.MM.yyyy HH:mm</maven.build.timestamp.format>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
@@ -57,8 +57,8 @@
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Common -->
-    <spring-boot.version>3.5.16</spring-boot.version>
-    <springtainer-common.version>2.0.0</springtainer-common.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
+    <springtainer-common.version>3.0.0-RC1</springtainer-common.version>
     <lombok.version>1.18.46</lombok.version>
     <!-- Other -->
     <!-- Testing -->
@@ -167,6 +167,7 @@
         <configuration>
           <release>${java.version}</release>
           <parameters>true</parameters>
+          <proc>full</proc>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/avides/springboot/springtainer/redis/RedisProperties.java
+++ b/src/main/java/com/avides/springboot/springtainer/redis/RedisProperties.java
@@ -20,6 +20,6 @@ public class RedisProperties extends AbstractEmbeddedContainerProperties
 
     public RedisProperties()
     {
-        setDockerImage("redis:6.2.22-alpine");
+        setDockerImage("redis:8.10.0-alpine");
     }
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,7 +17,7 @@
 			"name": "embedded.container.redis.docker-image",
 			"type": "java.lang.String",
 			"description": "Docker-image",
-			"defaultValue": "redis:6.2.22-alpine"
+			"defaultValue": "redis:8.10.0-alpine"
 		},
 		{
 			"name": "embedded.container.redis.port",

--- a/src/test/java/com/avides/springboot/springtainer/redis/RedisPropertiesTest.java
+++ b/src/test/java/com/avides/springboot/springtainer/redis/RedisPropertiesTest.java
@@ -13,7 +13,7 @@ public class RedisPropertiesTest
         var properties = new RedisProperties();
         assertTrue(properties.isEnabled());
         assertEquals(30, properties.getStartupTimeout());
-        assertEquals("redis:6.2.22-alpine", properties.getDockerImage());
+        assertEquals("redis:8.10.0-alpine", properties.getDockerImage());
 
         assertEquals(6379, properties.getPort());
     }


### PR DESCRIPTION
Hebt `springtainer-redis` auf Spring Boot 4.1.0 und Java 25. Zielversion **3.0.0-RC1**.

- Image auf `redis:8.10.0-alpine`.

### Merge-Reihenfolge

Die CI dieses PRs bleibt so lange rot, bis die folgenden Libraries gemergt und released sind - ihre RC-Artefakte liegen bisher nur lokal:

- `springtainer-common`

Ticket: https://avides.atlassian.net/browse/LIBRARIES-1752
Epic: https://avides.atlassian.net/browse/ITGS-470